### PR TITLE
Add pip upgrade command

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -15,4 +15,5 @@ sudo apt-get install -y python3-setuptools
 
 # Install Docker compose
 sudo apt-get install curl libffi-dev python-openssl libssl-dev zlib1g-dev gcc g++ make -y
+python3 -m pip install --upgrade pip
 sudo pip3 install docker-compose


### PR DESCRIPTION
After installing Jetpack on Jetson nano immediately, I ran docker_setup.sh, and the following error occurred
ModuleNotFoundError: No module named 'setuptools_rust'
The default pip is version 9, which is resolved after upgrading the pip module