### PR TITLE
Fixed dsl image version  tag

### DIFF
--- a/dgpu/docker_run.sh
+++ b/dgpu/docker_run.sh
@@ -16,4 +16,4 @@ docker run \
 	-v ~/contrib/deepstream-services-library/:/opt/dsl/deepstream-services-library/ \
 	-v ~/contrib/DeepStream-Yolo:/opt/dsl/DeepStream-Yolo/ \
 	-v ~/contrib/yolov5:/opt/dsl/yolov5 \
-	dsl:dgpu
+	dsl:0


### PR DESCRIPTION
```
access control disabled, clients can connect from any host
Unable to find image 'dsl:dgpu' locally
docker: Error response from daemon: pull access denied for dsl, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.

```
Fixed the  above error by resolving the docker image tag. 
